### PR TITLE
Fix code scanning alert no. 10: Accepting unknown SSH host keys when using Paramiko

### DIFF
--- a/opencanary/test/module_test.py
+++ b/opencanary/test/module_test.py
@@ -392,7 +392,7 @@ class TestSSHModule(unittest.TestCase):
 
     def setUp(self):
         self.connection = paramiko.SSHClient()
-        self.connection.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.connection.set_missing_host_key_policy(paramiko.RejectPolicy())
 
     def test_ssh_with_basic_login(self):
         """


### PR DESCRIPTION
Fixes [https://github.com/kallie9750/opencanary/security/code-scanning/10](https://github.com/kallie9750/opencanary/security/code-scanning/10)

To fix the problem, we need to replace the use of `AutoAddPolicy` with `RejectPolicy` in the test suite. This change ensures that the SSH client will not accept unknown host keys, maintaining the security of the connection even in a testing environment.

- Change the missing host key policy from `AutoAddPolicy` to `RejectPolicy`.
- This change should be made in the `setUp` method of the `TestSSHModule` class in the `opencanary/test/module_test.py` file.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
